### PR TITLE
Add monitoring addons for New Relic, Datadog, and Dynatrace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/terraform:1": {}
+  }
+}

--- a/patterns/gitops/getting-started-argocd/README.md
+++ b/patterns/gitops/getting-started-argocd/README.md
@@ -343,3 +343,52 @@ export TF_VAR_gitops_workload_org=https://github.com/aws-ia
 export TF_VAR_gitops_workload_repo=terraform-aws-eks-blueprints
 export TF_VAR_gitops_workload_revision=main
 ```
+
+## Configuring New Relic, Datadog, and Dynatrace
+
+To configure New Relic, Datadog, and Dynatrace, follow the steps below:
+
+### New Relic
+
+1. Set the following environment variables with your New Relic API key and account ID:
+
+```shell
+export TF_VAR_newrelic_api_key=<your_newrelic_api_key>
+export TF_VAR_newrelic_account_id=<your_newrelic_account_id>
+```
+
+2. Apply the Terraform configuration to deploy the New Relic addon:
+
+```shell
+terraform apply -auto-approve
+```
+
+### Datadog
+
+1. Set the following environment variables with your Datadog API key and application key:
+
+```shell
+export TF_VAR_datadog_api_key=<your_datadog_api_key>
+export TF_VAR_datadog_app_key=<your_datadog_app_key>
+```
+
+2. Apply the Terraform configuration to deploy the Datadog addon:
+
+```shell
+terraform apply -auto-approve
+```
+
+### Dynatrace
+
+1. Set the following environment variables with your Dynatrace API URL and API token:
+
+```shell
+export TF_VAR_dynatrace_api_url=<your_dynatrace_api_url>
+export TF_VAR_dynatrace_api_token=<your_dynatrace_api_token>
+```
+
+2. Apply the Terraform configuration to deploy the Dynatrace addon:
+
+```shell
+terraform apply -auto-approve
+```

--- a/patterns/gitops/getting-started-argocd/bootstrap/addons.yaml
+++ b/patterns/gitops/getting-started-argocd/bootstrap/addons.yaml
@@ -24,3 +24,87 @@ spec:
         name: '{{name}}'
       syncPolicy:
         automated: {}
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: newrelic-addons
+  namespace: argocd
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - clusters: {}
+  template:
+    metadata:
+      name: newrelic-addons
+    spec:
+      project: default
+      source:
+        repoURL: '{{metadata.annotations.addons_repo_url}}'
+        path: '{{metadata.annotations.addons_repo_basepath}}newrelic'
+        targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+        directory:
+          recurse: true
+      destination:
+        namespace: argocd
+        name: '{{name}}'
+      syncPolicy:
+        automated: {}
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: datadog-addons
+  namespace: argocd
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - clusters: {}
+  template:
+    metadata:
+      name: datadog-addons
+    spec:
+      project: default
+      source:
+        repoURL: '{{metadata.annotations.addons_repo_url}}'
+        path: '{{metadata.annotations.addons_repo_basepath}}datadog'
+        targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+        directory:
+          recurse: true
+      destination:
+        namespace: argocd
+        name: '{{name}}'
+      syncPolicy:
+        automated: {}
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dynatrace-addons
+  namespace: argocd
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - clusters: {}
+  template:
+    metadata:
+      name: dynatrace-addons
+    spec:
+      project: default
+      source:
+        repoURL: '{{metadata.annotations.addons_repo_url}}'
+        path: '{{metadata.annotations.addons_repo_basepath}}dynatrace'
+        targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+        directory:
+          recurse: true
+      destination:
+        namespace: argocd
+        name: '{{name}}'
+      syncPolicy:
+        automated: {}

--- a/patterns/gitops/getting-started-argocd/main.tf
+++ b/patterns/gitops/getting-started-argocd/main.tf
@@ -38,6 +38,21 @@ provider "kubernetes" {
   }
 }
 
+provider "newrelic" {
+  api_key = var.newrelic_api_key
+  account_id = var.newrelic_account_id
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
+  app_key = var.datadog_app_key
+}
+
+provider "dynatrace" {
+  api_url = var.dynatrace_api_url
+  api_token = var.dynatrace_api_token
+}
+
 locals {
   name   = "getting-started-gitops"
   region = var.region
@@ -99,6 +114,9 @@ locals {
     enable_prometheus_adapter              = try(var.addons.enable_prometheus_adapter, false)
     enable_secrets_store_csi_driver        = try(var.addons.enable_secrets_store_csi_driver, false)
     enable_vpa                             = try(var.addons.enable_vpa, false)
+    enable_newrelic                        = try(var.addons.enable_newrelic, false)
+    enable_datadog                         = try(var.addons.enable_datadog, false)
+    enable_dynatrace                       = try(var.addons.enable_dynatrace, false)
   }
   addons = merge(
     local.aws_addons,
@@ -178,6 +196,9 @@ module "eks_blueprints_addons" {
   enable_karpenter                    = local.aws_addons.enable_karpenter
   enable_velero                       = local.aws_addons.enable_velero
   enable_aws_gateway_api_controller   = local.aws_addons.enable_aws_gateway_api_controller
+  enable_newrelic                     = local.oss_addons.enable_newrelic
+  enable_datadog                      = local.oss_addons.enable_datadog
+  enable_dynatrace                    = local.oss_addons.enable_dynatrace
 
   tags = local.tags
 }

--- a/patterns/gitops/getting-started-argocd/variables.tf
+++ b/patterns/gitops/getting-started-argocd/variables.tf
@@ -74,3 +74,39 @@ variable "gitops_workload_path" {
   type        = string
   default     = "getting-started-argocd/k8s"
 }
+
+# New Relic
+variable "newrelic_api_key" {
+  description = "New Relic API key"
+  type        = string
+  default     = ""
+}
+variable "newrelic_account_id" {
+  description = "New Relic account ID"
+  type        = string
+  default     = ""
+}
+
+# Datadog
+variable "datadog_api_key" {
+  description = "Datadog API key"
+  type        = string
+  default     = ""
+}
+variable "datadog_app_key" {
+  description = "Datadog application key"
+  type        = string
+  default     = ""
+}
+
+# Dynatrace
+variable "dynatrace_api_url" {
+  description = "Dynatrace API URL"
+  type        = string
+  default     = ""
+}
+variable "dynatrace_api_token" {
+  description = "Dynatrace API token"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Add integration for New Relic, Datadog, and Dynatrace to the GitOps pattern.

* **main.tf**:
  - Add providers for New Relic, Datadog, and Dynatrace.
  - Add variables for New Relic, Datadog, and Dynatrace configurations.
  - Enable New Relic, Datadog, and Dynatrace in the addons configuration.

* **addons.yaml**:
  - Add ArgoCD ApplicationSet for New Relic.
  - Add ArgoCD ApplicationSet for Datadog.
  - Add ArgoCD ApplicationSet for Dynatrace.

* **variables.tf**:
  - Add variables for New Relic API key and account ID.
  - Add variables for Datadog API key and application key.
  - Add variables for Dynatrace API URL and API token.

* **README.md**:
  - Add instructions for configuring New Relic, Datadog, and Dynatrace.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abcxyzbank/terraform-aws-eks-blueprints/pull/1?shareId=7d81df91-8d8e-4d13-9c1a-047d16b13a25).